### PR TITLE
Remove extraneous template parameter lists, as reported by clang

### DIFF
--- a/include/simmo/basic_vector.hpp
+++ b/include/simmo/basic_vector.hpp
@@ -128,7 +128,6 @@ namespace comparison
 namespace std
 {
 
-template<>
 template<typename T, size_t N>
 struct hash<simmo::basic_vector<T, N>>
 {

--- a/include/simmo/point.hpp
+++ b/include/simmo/point.hpp
@@ -93,7 +93,6 @@ typedef point<double, 3> point3d;
 namespace std
 {
 
-template<>
 template<typename T, size_t N>
 struct hash<simmo::point<T, N>>
 {

--- a/include/simmo/vector.hpp
+++ b/include/simmo/vector.hpp
@@ -160,7 +160,6 @@ typedef vector<double, 3> vector3d;
 namespace std
 {
 
-template<>
 template<typename T, size_t N>
 struct hash<simmo::vector<T, N>>
 {


### PR DESCRIPTION
These are allowed by the spec, but that is regarded as a [design flaw](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#293). This commit silences `clang` by removing them.
